### PR TITLE
Bump pinned ghul.runtime 1.3.3 → 1.3.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="1.3.3" />
+    <PackageVersion Include="ghul.runtime" Version="1.3.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Republish picks up the cross-assembly globals fix (degory/ghul#1254) and ~70 versions of accumulated runtime fixes. Required ahead of the compiler PR that switches the `xs |` parser desugar to call the now-importable global `Ghul.Pipes.pipe` instead of the legacy `Ghul.Pipes.Factory.from` — examples that use the pipe operator otherwise fail to resolve `Ghul.Pipes.pipe` against the older runtime.