### PR TITLE
Adapt stringify_tree else for variant narrowing; bump compiler 0.8.113 → 0.8.122

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.113",
+      "version": "0.8.122",
       "commands": [
         "ghul-compiler"
       ],

--- a/examples/functional/functional.ghul
+++ b/examples/functional/functional.ghul
@@ -311,7 +311,7 @@ tree_example[T](leaves: Collections.List[T]) is
             let (left, right) = t in
             "({rec(left)}, {rec(right)})"
         else
-            "{t.leaf}"
+            "{t.value}"
         fi;
 
     write_line(stringify_tree(tree));


### PR DESCRIPTION
Enhancements:
- `examples/functional/functional.ghul` `stringify_tree` else: `t.leaf` → `t.value`. Picks up else-branch narrowing on two-variant unions (ghul#1266): the else body now sees `t` as LEAF, and variant scope's `find_member` suppresses union-owned accessors, so the union's `leaf` accessor is no longer in scope — LEAF's `value` field is. Same shadow that already applies to `t.node` in already-narrowed then branches.

Technical:
- Pin bump 0.8.113 → 0.8.122. Earlier compilers reject the migrated source (no else narrowing); the migration commit lived on `next` until the compiler republished.