### PR TITLE
Migrate string concat to interpolation; bump compiler 0.8.124 → 0.8.126, runtime 2.0.0 → 2.0.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.124",
+      "version": "0.8.126",
       "commands": [
         "ghul-compiler"
       ],
       "rollForward": false
     },
     "ghul.test": {
-      "version": "1.3.5",
+      "version": "1.3.10",
       "commands": [
         "ghul-test"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="2.0.0" />
+    <PackageVersion Include="ghul.runtime" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/examples/object-oriented/object-oriented.ghul
+++ b/examples/object-oriented/object-oriented.ghul
@@ -109,7 +109,7 @@ si
 class STRING_CONCATENATION: Operation[string] is
     init() is si
 
-    execute(left: string, right: string) -> string => left + right;
+    execute(left: string, right: string) -> string => "{left}{right}";
 si
 
 class STRING_SUBTRACTION: Operation[string] is

--- a/examples/pipes/pipes.ghul
+++ b/examples/pipes/pipes.ghul
@@ -16,7 +16,7 @@ entry() is
     // anonymous functions can have a block body:
     let h = (k: int) is
         let result = "k is ";
-        result = result + k;
+        result = "{result}{k}";
         return result; // return type is inferred here
     si;
 

--- a/examples/type-inference/type-inference.ghul
+++ b/examples/type-inference/type-inference.ghul
@@ -193,7 +193,7 @@ lambdas_from_call_context() is
     write_line("sum: {sum}");
 
     // chained calls keep flowing the inferred types through:
-    let labelled = [1, 2, 3] | .map(n => "[{n}]") .reduce("", (acc, s) => acc + s);
+    let labelled = [1, 2, 3] | .map(n => "[{n}]") .reduce("", (acc, s) => "{acc}{s}");
     write_line("labelled: {labelled}");
 si
 

--- a/root/root-entry.ghul
+++ b/root/root-entry.ghul
@@ -10,7 +10,8 @@ use IO.Std.write_line;
 
 root_entry() =>
     write_line(
-        "This root project is a dummy to allow all the examples to be loaded in the same VSCode workspace.\n" +
-        "You need to build and run each example subproject individually. For example: \n\n" + 
+        "This root project is a dummy to allow all the examples to be loaded in the same VSCode workspace.\n"
+        "You need to build and run each example subproject individually. For example: \n\n"
         "    dotnet run --project examples/hello-world"
     );
+


### PR DESCRIPTION
Technical:
- Replaces `+(string, object)` overload uses with string interpolation:
  - `object-oriented.ghul`: `STRING_CONCATENATION.execute(left, right) => left + right` becomes `=> "{left}{right}"`.
  - `pipes.ghul`: inner-lambda `result = result + k` becomes `result = "{result}{k}"`.
  - `type-inference.ghul`: `reduce` step `(acc, s) => acc + s` becomes `(acc, s) => "{acc}{s}"`.
  - `root-entry.ghul`: multi-line `"..." + "..." + "..."` becomes adjacent string literals (which are now folded into a single token by the compiler).
- Bumps `ghul.compiler` 0.8.124 → 0.8.126 (needed for adjacent-string-literal support in `root-entry.ghul`).
- Bumps `ghul.test` 1.3.5 → 1.3.10.
- Bumps `ghul.runtime` 2.0.0 → 2.0.1.
- All 9 examples build and run with unchanged output.
- Preparatory work for removing the `+(string, object) -> string` overload from the compiler in a future release.