### PR TITLE
Bump compiler pin 0.8.126 → 0.9.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.126",
+      "version": "0.9.1",
       "commands": [
         "ghul-compiler"
       ],


### PR DESCRIPTION
Technical:
- Picks up the post-0.8.126 compiler releases. 0.9.0 dropped the `+(string, object) -> string` overload (degory/ghul#1274); examples already migrated to interpolation in #31. 0.9.1 was a routine post-0.9.0 publish with no language-visible changes affecting examples.
- All integration tests and the project-level build pass against 0.9.1.