### PR TITLE
Migrate ghul-examples to trailing `mut` for reassigned local bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.9.1",
+      "version": "0.9.5",
       "commands": [
         "ghul-compiler"
       ],

--- a/examples/control-flow/control-flow.ghul
+++ b/examples/control-flow/control-flow.ghul
@@ -55,8 +55,7 @@ if_expression_examples() is
 si
 
 while_examples() is
-    let i = 0;
-    while i < 10 do
+    let i mut = 0;    while i < 10 do
         assert i < 10;
         i = i + 1;
 
@@ -67,8 +66,7 @@ while_examples() is
 si
 
 for_examples() is
-    let count = 0;
-
+    let count mut = 0;
     for i in 0..10 do
         assert i >= 0 /\ i < 10;
 
@@ -111,8 +109,7 @@ try_examples() is
 
     // try finally for ensuring clean-up code is run:
 
-    let is_resource_in_use = false;
-    try
+    let is_resource_in_use mut = false;    try
         is_resource_in_use = true;
         write_line("resource acquired");
         throw System.Exception("oops: exception with resource held");

--- a/examples/generics/generics.ghul
+++ b/examples/generics/generics.ghul
@@ -13,8 +13,7 @@ entry() is
 si
 
 count_things[E](things: Iterable[E]) -> int is
-    let count = 0;
-
+    let count mut = 0;
     for thing in things do
         count = count + 1;
     od

--- a/examples/pipes/pipes.ghul
+++ b/examples/pipes/pipes.ghul
@@ -15,8 +15,7 @@ entry() is
 
     // anonymous functions can have a block body:
     let h = (k: int) is
-        let result = "k is ";
-        result = "{result}{k}";
+        let result mut = "k is ";        result = "{result}{k}";
         return result; // return type is inferred here
     si;
 


### PR DESCRIPTION
Follow-up to ghul#1124: bare `let` bindings that are subsequently reassigned are flagged by the new `--warn-implicit-mutable-let` warning; each such site in the examples is rewritten to declare with trailing `mut` (`<binding> mut`, matching the existing `name: type public` modifier-after-name convention).

Enhancements:
- Bindings that get reassigned now declare with trailing `mut`:
  - `examples/control-flow/control-flow.ghul:58` — `let i mut = 0;` in `while_examples()`.
  - `examples/control-flow/control-flow.ghul:70` — `let count mut = 0;` in `for_examples()`.
  - `examples/control-flow/control-flow.ghul:114` — `let is_resource_in_use mut = false;` for the try/finally example.
  - `examples/generics/generics.ghul:16` — `let count mut = 0;` in `count_things[E]`.
  - `examples/pipes/pipes.ghul:18` — `let result mut = "k is ";` in the block-body anonymous function `h`.

Technical:
- Compiler pin bumped to 0.9.5 (first published release supporting `let mut`).
- No semantic or IL change. All 10 integration tests pass with zero remaining `--warn-implicit-mutable-let` warnings.