### PR TITLE
Restore line breaks the phase B migration script collapsed

### DIFF
--- a/examples/control-flow/control-flow.ghul
+++ b/examples/control-flow/control-flow.ghul
@@ -55,7 +55,9 @@ if_expression_examples() is
 si
 
 while_examples() is
-    let i mut = 0;    while i < 10 do
+    let i mut = 0;
+
+    while i < 10 do
         assert i < 10;
         i = i + 1;
 
@@ -67,6 +69,7 @@ si
 
 for_examples() is
     let count mut = 0;
+
     for i in 0..10 do
         assert i >= 0 /\ i < 10;
 
@@ -109,7 +112,9 @@ try_examples() is
 
     // try finally for ensuring clean-up code is run:
 
-    let is_resource_in_use mut = false;    try
+    let is_resource_in_use mut = false;
+
+    try
         is_resource_in_use = true;
         write_line("resource acquired");
         throw System.Exception("oops: exception with resource held");

--- a/examples/generics/generics.ghul
+++ b/examples/generics/generics.ghul
@@ -14,6 +14,7 @@ si
 
 count_things[E](things: Iterable[E]) -> int is
     let count mut = 0;
+
     for thing in things do
         count = count + 1;
     od

--- a/examples/pipes/pipes.ghul
+++ b/examples/pipes/pipes.ghul
@@ -15,7 +15,8 @@ entry() is
 
     // anonymous functions can have a block body:
     let h = (k: int) is
-        let result mut = "k is ";        result = "{result}{k}";
+        let result mut = "k is ";
+        result = "{result}{k}";
         return result; // return type is inferred here
     si;
 


### PR DESCRIPTION
Bugs fixed:
- The bulk-rewrite script that introduced trailing `mut` in #34 ate the newline after `let X mut = ...;` in three places, leaving the next statement on the same line: `examples/control-flow/control-flow.ghul:58` (`let i mut = 0;    while ...`), `examples/control-flow/control-flow.ghul:112` (`let is_resource_in_use mut = false;    try`), and `examples/pipes/pipes.ghul:18` (`let result mut = "k is ";        result = ...`). Each is split back onto two lines.
- Same script also removed the blank line between `let count mut = 0;` and the following `for` loop in two places: `examples/control-flow/control-flow.ghul` (for_examples) and `examples/generics/generics.ghul`. Restored.