### PR TITLE
Add lazy-sequence generator example built on Pipe[T]

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.9.5",
+      "version": "0.9.9",
       "commands": [
         "ghul-compiler"
       ],

--- a/examples/functional/functional.ghul
+++ b/examples/functional/functional.ghul
@@ -1,6 +1,12 @@
 use IO.Std.write_line;
 use Collections.LIST;
 
+use Generators.STEP;
+use Generators.generator;
+
+use STEP.DONE;
+use STEP.YIELD;
+
 entry() is
     first_class_functions();
     map_filter_reduce_examples();
@@ -348,63 +354,42 @@ partial_application_examples() is
     write_line("add_10(3): {add_10(3)}");
 si
 
-// we don't have true lazy evaluation but we can try to approximate it
-
-// a generic infinite sequence generator with arbitrary state
-class GENERATOR[T, S]: Collections.Iterator[T], Collections.Iterable[T] is
-    current: T;
-    iterator: Collections.Iterator[T] => self;
-
-    _initial: S;
-    _state: S;
-    _generator: S -> (S, T); // given the current state, return the next state and the current value
-
-    init(initial: S, generator: S -> (S, T)) is
-        _initial = initial;
-        _generator = generator;
-        reset();
-    si
-
-    init() is
-        reset();
-    si
-        
-    move_next() -> bool is
-        (_state, current) = _generator(_state);
-        return true;
-    si
-
-    reset() is
-        _state = _initial;
-    si
-
-    dispose() is
-    si
-si
+// Lazy sequences via the GENERATOR_STEP union and GENERATOR_PIPE class
+// in generators.ghul. Each step closure returns either DONE (sequence is
+// over) or YIELD(value, rest) — a value plus a thunk producing the next
+// step. The GENERATOR_PIPE wraps a starting thunk and surfaces the
+// sequence through the standard Pipe[T] combinator API.
 
 generator_examples() is
-    // generates an infinite sequence of fibonacci numbers:
-    let fibonacci_sequence = GENERATOR(
-        (0, 1),
-        (state: (int, int)) =>
-            let
-                (prev, current) = state,
-                next = prev + current
-            in
-                ((current, next), next)
-    );
+    // terminating generator: counting n .. 1, then DONE.
+    // `rec` referenced from the nested thunk resolves to the
+    // enclosing recursive lambda via outer-rec capture.
 
-    // generates an infinite sequence of factorials:
-    let factorial_sequence = GENERATOR(
-        (1, 1),
-        (state) =>
-            let
-                (p, prev) = state,
-                n = p + 1,
-                next = prev * n
-            in
-                ((n, next), next)            
-    );
+    let counting = n -> STEP[int] rec =>
+        if n == 0 then
+            DONE[int]()
+        else
+            YIELD(n, () => rec(n - 1))
+        fi;
+
+    let fib_step = (prev: int, current: int) -> STEP[int] rec =>
+        YIELD(current, () => rec(current, prev + current));
+
+    let factorial_step = (n: int, prev: int) -> STEP[int] rec =>
+        let
+            next_n = n + 1,
+            next   = prev * next_n
+        in
+            YIELD(next, () => rec(next_n, next));
+
+    // terminating generator — exhausts naturally via DONE
+    let count_down = generator(() => counting(5));
+
+    write_line("counting down from 5: {count_down}");
+
+    // infinite generators bounded by .take(...)
+    let fibonacci_sequence = generator(() => fib_step(1, 1));
+    let factorial_sequence = generator(() => factorial_step(1, 1));
 
     write_line("first 10 fibonacci numbers: {fibonacci_sequence | .take(10)}");
     write_line("first 10 factorial numbers: {factorial_sequence | .take(10)}");

--- a/examples/functional/generators.ghul
+++ b/examples/functional/generators.ghul
@@ -1,0 +1,57 @@
+namespace Generators is
+    use Collections;
+    use Ghul.Pipes.Pipe;
+
+    union STEP[T] is
+        DONE;
+        YIELD(value: T, rest: () -> STEP[T]);
+    si
+
+    class GENERATOR_PIPE[T]: Pipe[T] is
+        _initial: () -> STEP[T];
+        _step:    () -> STEP[T];
+        _done:    bool;
+
+        current: T;
+
+        iterator: Iterator[T] => self;
+
+        init(initial: () -> STEP[T]) is
+            _initial = initial;
+            _step = initial;
+        si
+
+        move_next() -> bool is
+            if _done then
+                return false;
+            fi
+
+            let s = _step();
+
+            if s.is_done then
+                _done = true;
+                return false;
+            elif s.is_yield then
+                let (v, r) = s;
+                current = v;
+                _step   = r;
+                return true;
+            fi
+
+            return false;
+        si
+
+        reset() is
+            _step = _initial;
+            _done = false;
+        si
+
+        to_string() -> string => join(", ");
+
+        dispose() is
+        si
+    si
+
+    generator[T](step: () -> STEP[T]) -> Pipe[T] =>
+        GENERATOR_PIPE[T](step);
+si

--- a/integration-tests/functional/generators.ghul
+++ b/integration-tests/functional/generators.ghul
@@ -1,0 +1,1 @@
+../../examples/functional/generators.ghul

--- a/integration-tests/functional/run.expected
+++ b/integration-tests/functional/run.expected
@@ -28,6 +28,7 @@ add_5(3): 8
 add_10(3): 13
 add_5(3): 8
 add_10(3): 13
+counting down from 5: 5, 4, 3, 2, 1
 first 10 fibonacci numbers: 1, 2, 3, 5, 8, 13, 21, 34, 55, 89
 first 10 factorial numbers: 2, 6, 24, 120, 720, 5040, 40320, 362880, 3628800, 39916800
 first 10 even fibonacci numbers: 2, 8, 34, 144, 610, 2584, 10946, 46368, 196418, 832040


### PR DESCRIPTION
Enhancements:
- New `examples/functional/generators.ghul` introduces a `Generators.STEP[T]` union (`DONE` / `YIELD(value, rest: () -> STEP[T])`) and a `GENERATOR_PIPE[T]: Ghul.Pipes.Pipe[T]` class that drives a starting thunk and surfaces the produced sequence through the standard pipe combinator API (`.take(n)`, `.filter(...)`, `.zip(...)`, `.map(...)`, etc.). A `generator[T](step: () -> STEP[T]) -> Pipe[T]` factory wraps the class.
- `examples/functional/functional.ghul:generator_examples` rewritten to use the new types: three lambda-defined step functions (`counting`, `fib_step`, `factorial_step`) demonstrate terminating and infinite generators. Each is a recursive lambda whose nested `() => …` thunk calls back into the lambda via `rec` directly — the outer-rec capture landed in compiler 0.9.9 so no `let r = rec in` workaround is needed.
- Adds `counting down from 5: 5, 4, 3, 2, 1` to the expected output demonstrating a terminating generator (vs. the infinite ones bounded by `.take(...)`).

Technical:
- Compiler pin bumped 0.9.6 → 0.9.9 (needed for nested-thunk `rec` capture).
- `integration-tests/functional/generators.ghul` symlinks the new example source per the repo's symlink-into-test-folder convention.
- 10/10 integration tests pass.