### PR TITLE
Port functional generator examples to STREAM[T, S] / stream() factory

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.10.1",
+      "version": "0.10.5",
       "commands": [
         "ghul-compiler"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="2.1.1" />
+    <PackageVersion Include="ghul.runtime" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/examples/functional/functional.ghul
+++ b/examples/functional/functional.ghul
@@ -2,6 +2,7 @@ use IO.Std.write_line;
 use Collections.LIST;
 
 use Ghul.Pipes.STREAM;
+use Ghul.Pipes.stream;
 use Ghul.Pipes.pipe;
 
 use STREAM.DONE;
@@ -354,49 +355,61 @@ partial_application_examples() is
     write_line("add_10(3): {add_10(3)}");
 si
 
-// Lazy sequences via `Ghul.Pipes.STREAM` (a union — `DONE` /
-// `YIELD(value, rest)`) wrapped through `pipe(() => step())` into a
-// `Pipe[T]`. Each step closure returns either DONE (sequence is over)
-// or `value || rest_expr` — a value, then a thunk producing the next
-// step (the `||` infix is parser sugar for
-// `YIELD(value, () => rest_expr)`).
+// Lazy sequences via `Ghul.Pipes.STREAM[T, S]` (a union — `DONE` /
+// `YIELD(value, state)`) consumed through `stream(initial, advance)`
+// which returns a `Pipe[T]`. The step lambda is pure
+// `S -> STREAM[T, S]`: returns `DONE` to terminate or
+// `value || next_state` to yield (the `||` infix is parser sugar for
+// `STREAM.YIELD(value, next_state)`). State type `S` is hidden from
+// the consumer — `stream()` returns a plain `Pipe[T]`.
 
 generator_examples() is
-    // terminating generator: counting n .. 1, then DONE.
-    // `rec` referenced from the `||` right operand resolves to the
-    // enclosing recursive lambda via outer-rec capture.
+    // terminating stream: counting n .. 1, then DONE. State is the
+    // current index; output is the index value.
 
-    let counting = n -> STREAM[int] rec =>
-        if n == 0 then
-            DONE[int]()
-        else
-            n || rec(n - 1)
-        fi;
+    let counting = (n: int) =>
+        stream`[int, int](
+            n,
+            i => if i == 0 then DONE[int, int]() else i || (i - 1) fi
+        );
 
-    let fibonacci_stream = (prev: int, current: int) -> STREAM[int] rec =>
-        current || rec(current, prev + current);
+    // infinite fibonacci. State is `(prev, current)`; output is `int`
+    // — state and output types are genuinely different.
 
-    let factorial_stream = (n: int, prev: int) -> STREAM[int] rec =>
-        let
-            next_n = n + 1,
-            next   = prev * next_n
-        in
-            next || rec(next_n, next);
+    let fibonacci = stream`[int, (int, int)](
+        (1, 1),
+        s => let (prev, current) = s in current || (current, prev + current)
+    );
 
-    // Each `step | ` lifts a `STREAM[int]` to `Pipe[int]` via pipe
-    // sugar; inlining the step calls at each use site builds a fresh
-    // stream every time and sidesteps reuse-with-reset questions. For
-    // the zip case, the right-hand step is lifted with a trailing
-    // `| ` because `.zip(other: Iterable[U])` expects an Iterable —
-    // a raw `STREAM[T]` isn't one.
+    // factorial. State is `(n, prev)`; output is `int`.
 
-    write_line("counting down from 5: {counting(5) | }");
+    let factorial = stream`[int, (int, int)](
+        (1, 1),
+        s => let (n, prev) = s in
+            let next_n = n + 1, next = prev * next_n in
+                next || (next_n, next)
+    );
 
-    write_line("first 10 fibonacci numbers: {fibonacci_stream(1, 1) | .take(10)}");
-    write_line("first 10 factorial numbers: {factorial_stream(1, 1) | .take(10)}");
-    write_line("first 10 even fibonacci numbers: {fibonacci_stream(1, 1) | .filter(x => x % 2 == 0) .take(10)}");
+    // chars-of-a-string: state is an `int` cursor, output is `char`.
+    // The canonical "state type differs from output type" example —
+    // input is closed over by the lambda, integer state is hidden
+    // inside the resulting `Pipe[char]`.
 
-    for (i, (fib, fact)) in fibonacci_stream(1, 1) | .zip(factorial_stream(1, 1) | ) .take(10) .index() do
+    let chars_of = (s: string) =>
+        let xs = s.to_char_array() in
+        stream`[char, int](
+            0,
+            i => if i == xs.count then DONE[char, int]() else xs[i] || (i + 1) fi
+        );
+
+    write_line("counting down from 5: {counting(5)}");
+    write_line("chars of hello: {chars_of("hello")}");
+
+    write_line("first 10 fibonacci numbers: {fibonacci | .take(10)}");
+    write_line("first 10 factorial numbers: {factorial | .take(10)}");
+    write_line("first 10 even fibonacci numbers: {fibonacci | .filter(x => x % 2 == 0) .take(10)}");
+
+    for (i, (fib, fact)) in fibonacci | .zip(factorial) .take(10) .index() do
         write_line("fibonacci {i} is {fib}");
         write_line("factorial {i} is {fact}");
     od;

--- a/integration-tests/functional/run.expected
+++ b/integration-tests/functional/run.expected
@@ -29,6 +29,7 @@ add_10(3): 13
 add_5(3): 8
 add_10(3): 13
 counting down from 5: 5, 4, 3, 2, 1
+chars of hello: h, e, l, l, o
 first 10 fibonacci numbers: 1, 2, 3, 5, 8, 13, 21, 34, 55, 89
 first 10 factorial numbers: 2, 6, 24, 120, 720, 5040, 40320, 362880, 3628800, 39916800
 first 10 even fibonacci numbers: 2, 8, 34, 144, 610, 2584, 10946, 46368, 196418, 832040


### PR DESCRIPTION
Enhancements:
- `generator_examples` rewritten to use the new `stream(initial, advance)` factory consuming `STREAM[T, S]` step results. State type `S` is now hidden from callers — `stream()` returns `Pipe[T]` directly, no need to wrap with `pipe(...)` or call a producer with explicit seed args at every use site.
- New `chars_of(string)` example demonstrates the canonical state-type-≠-output-type case: state is an `int` cursor over a `char[]`, output is `char`. Closes the "STREAM with int state producing char output" gap that motivated the redesign in ghul-runtime 3.0.1 and ghul 0.10.5.
- Recursive-lambda forms (`counting(5)` / `fibonacci_stream(1, 1)`) replaced by value-form streams — no `rec` capture, no closure-per-yield, no state shape leaked into the caller-visible signature.

Technical:
- Compiler pin bumped 0.10.1 → 0.10.5; runtime pin bumped 2.1.1 → 3.0.1.
- The branch was also pushed to `ghul-examples/next` while the paired compiler PR was in flight so its examples_tests CI could pick up the migration via the breaking-change-coordination mechanism. Now that the compiler has published, `next` becomes equal to `main` once this merges and can be deleted at convenience.