### PR TITLE
Fix examples flagged by definite-return/assignment analysis

### DIFF
--- a/examples/functional/functional.ghul
+++ b/examples/functional/functional.ghul
@@ -142,14 +142,10 @@ mutual_recursion_example() is
     write_line("odd(10): {is_odd(10)}");
 si
 
-// mututal recursion with named functions, doesn't require any workarounds:
-is_even(n: int) -> bool is
-    if n == 0 then true else is_odd(n - 1) fi;
-si
+// mutual recursion with named functions, doesn't require any workarounds:
+is_even(n: int) -> bool => if n == 0 then true else is_odd(n - 1) fi;
 
-is_odd(n: int) -> bool is
-    if n == 0 then false else is_even(n - 1) fi;
-si
+is_odd(n: int) -> bool => if n == 0 then false else is_even(n - 1) fi;
 
 // immutable data structures and pure functions
 immutable_data_structures_and_pure_functions() is

--- a/examples/object-oriented/object-oriented.ghul
+++ b/examples/object-oriented/object-oriented.ghul
@@ -39,6 +39,11 @@ si
 class CALCULATOR[T] is
     _operations: Collections.MAP[string, Operation[T]];
 
+    // fields are initialized to the default value of their type (0, false,
+    // null, ...); `_default` is never assigned, so it keeps that value and
+    // memory can be reset to it
+    _default: T;
+
     memory: T;
 
     init(operations: Collections.Iterable[(name: string, operation: Operation[T])]) is
@@ -70,8 +75,7 @@ class CALCULATOR[T] is
         fi;
 
     clear_memory() is
-        let def: T; // uninitialized variable has default value
-        memory = def;
+        memory = _default;
     si
 si
 


### PR DESCRIPTION
Bugs fixed:
- the named `is_even` / `is_odd` functions in the functional example were block-bodied with no `return`, so they fell off the end and always yielded `false` — made them expression-bodied

Technical:
- reset `CALCULATOR.clear_memory` from a `_default` field rather than reading an uninitialised local