### PR TITLE
Use the `default` value expression in the calculator example

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.10.5",
+      "version": "0.12.0",
       "commands": [
         "ghul-compiler"
       ],

--- a/examples/object-oriented/object-oriented.ghul
+++ b/examples/object-oriented/object-oriented.ghul
@@ -39,11 +39,6 @@ si
 class CALCULATOR[T] is
     _operations: Collections.MAP[string, Operation[T]];
 
-    // fields are initialized to the default value of their type (0, false,
-    // null, ...); `_default` is never assigned, so it keeps that value and
-    // memory can be reset to it
-    _default: T;
-
     memory: T;
 
     init(operations: Collections.Iterable[(name: string, operation: Operation[T])]) is
@@ -75,7 +70,7 @@ class CALCULATOR[T] is
         fi;
 
     clear_memory() is
-        memory = _default;
+        memory = default;
     si
 si
 


### PR DESCRIPTION
- bump the pinned compiler to 0.12.0
- replace the `_default` field placeholder in the object-oriented calculator with a `default` value expression in `clear_memory`