### PR TITLE
Make the `if let` example's lookup return `CAT?`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.12.3",
+      "version": "0.12.13",
       "commands": [
         "ghul-compiler"
       ],

--- a/examples/if-let/if-let.ghul
+++ b/examples/if-let/if-let.ghul
@@ -51,7 +51,7 @@ greet(pet: CAT) is
     fi
 si
 
-find_pet(name: string) -> CAT is
+find_pet(name: string) -> CAT? is
     if name == "Felix" then
         return CAT(name);
     fi


### PR DESCRIPTION
Enhancements:
- `find_pet` in the `if let` example returns `CAT?` — it can return
  `null`, so the nullable return type is the honest signature, and it
  is what `if let` is meant to consume.