### PR TITLE
Infer the element and parameter types in the closures and functional examples

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.12.13",
+      "version": "0.12.20",
       "commands": [
         "ghul-compiler"
       ],
       "rollForward": false
     },
     "ghul.test": {
-      "version": "1.3.10",
+      "version": "1.3.13",
       "commands": [
         "ghul-test"
       ],

--- a/examples/closures/closures.ghul
+++ b/examples/closures/closures.ghul
@@ -17,8 +17,10 @@ entry() is
         write_line("f({i}) = {f(i)}");
     od
 
-    // list_of_gs is a list of 2-tuples, each one having an integer and a function element:
-    let list_of_gs = LIST[(i: int, g: () -> int)]();
+    // list_of_gs is a list of 2-tuples, each one having an integer and a function element.
+    // its element type doesn't need to be written out - the compiler infers it from the
+    // add() call below:
+    let list_of_gs = LIST();
 
     for i in 1::10 do
         // create a function that captures a value - in this case the loop variable i

--- a/examples/functional/functional.ghul
+++ b/examples/functional/functional.ghul
@@ -267,7 +267,7 @@ option_example() is
     let some_int = SOME(42);
     let none_int = NONE[int]();
 
-    let stringify_option = (o: Option[int]) rec =>
+    let stringify_option = o rec =>
         if o.is_some then
             "{o.value}"
         else


### PR DESCRIPTION
Enhancements:

- `closures`: the list of captured-function tuples is built with a bare `LIST()`, with the element type inferred from the `add()` calls.
- `functional`: drop the explicit `Option[int]` parameter type on the `stringify_option` lambda — it is inferred from the call sites.

Technical:

- Bump the pinned `ghul.compiler` (0.12.3 → 0.12.20) and `ghul.test` (1.3.10 → 1.3.13).