### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Restore .NET tools
       run: dotnet tool restore


### PR DESCRIPTION
Updates the CI workflow's `actions/checkout` action from the deprecated v3 to v4.