### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Restore .NET tools
       run: dotnet tool restore


### PR DESCRIPTION
Follow-up to #56. v4 → v6 picks up the action's Node 24 runtime and the v6 persistent-credentials change. Latest major as of this writing.