### PR TITLE
Switch devcontainer image to standard MS .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "ghcr.io/degory/ghul/devcontainer:dotnet",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
 	"containerUser": "vscode",
 	"customizations": {
 		"vscode" : {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Note that some of the configuration for these projects is being inherited from t
 
 ### using a different devcontainer image
 
-The project is configured to use the [ghūl development container image](https://github.com/degory/ghul/pkgs/container/ghul%2Fdevcontainer). You can use a different container image if you prefer - just edit the configuration in the `.devcontainer` folder accordingly. Make sure the image you select includes the .NET 8.0 SDK, with `dotnet` on the PATH.
+The project is configured to use a standard .NET 8 dev container image — for example [`mcr.microsoft.com/devcontainers/dotnet:8.0`](https://hub.docker.com/r/microsoft/devcontainers-dotnet). You can use a different container image if you prefer - just edit the configuration in the `.devcontainer` folder accordingly. Make sure the image you select includes the .NET 8.0 SDK, with `dotnet` on the PATH.
 
 ## language extension features
 The ghūl language extension for Visual Studio Code provides a few features that make working on ghūl projects easier, including:


### PR DESCRIPTION
The custom `ghcr.io/degory/ghul/devcontainer:dotnet` image was providing a system-wide install of `ghul.compiler` that the local tool manifest shadowed anyway, plus a `vscode` non-root user that `mcr.microsoft.com/devcontainers/dotnet:8.0` already provides. Switching to the standard MS image removes the dependency on a bespoke image without losing anything used in practice.

Technical:

- `.devcontainer/devcontainer.json` points at `mcr.microsoft.com/devcontainers/dotnet:8.0`. The compiler is installed from the tool manifest on first `dotnet tool restore`.
- README's "using a different devcontainer image" section is updated to name the standard MS image as the configured one.

Sibling PRs (same theme): degory/ghul, degory/ghul-test, degory/ghul-runtime, degory/ghul-dev.